### PR TITLE
Update mokes-detect.sh

### DIFF
--- a/mokes-detect.sh
+++ b/mokes-detect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-FILES=("$HOME/Library/App Store/storeuserd" "$HOME/Library/com.apple.spotlight/SpotlightHelper" "$HOME/Library/Dock/com.apple.dock.cache" "$HOME/Library/Skype/SkypeHelper" "$HOME/Library/Dropbox/DropboxCache" "$HOME/Library/Google/Chrome/nacld" "$HOME/Library/Firefox/Profiles/profiled" "$HOME/Library/LaunchAgents/$filename.plist" "$TMPDIR/ss*-$date-$time-$ms.sst" "$TMPDIR/aa*-$date-$time-$ms.aat" "$TMPDIR/kk*-$date-$time-$ms.kkt" "$TMPDIR/dd*-$date-$time-$ms.ddt")
+FILES=("$HOME/Library/App Store/storeuserd" "$HOME/Library/com.apple.spotlight/SpotlightHelper" "$HOME/Library/Dock/com.apple.dock.cache" "$HOME/Library/Skype/SkypeHelper" "$HOME/Library/Dropbox/DropboxCache" "$HOME/Library/Google/Chrome/nacld" "$HOME/Library/Firefox/Profiles/profiled" "$HOME/Library/LaunchAgents/$filename.plist" "$TMPDIR/ss*.sst" "$TMPDIR/aa*.aat" "$TMPDIR/kk*.kkt" "$TMPDIR/dd*.ddt" "/tmp/ss*.sst" "/tmp/aa*.aat" "/tmp/kk*.kkt" "/tmp/dd*.ddt")
 INFECTED=0
 
 for FILE in "${FILES[@]}"; do


### PR DESCRIPTION
removes not available timestamp info from file pattern and adds `/tmp/` to checklist.